### PR TITLE
Add world clock page

### DIFF
--- a/js/time.js
+++ b/js/time.js
@@ -1,0 +1,10 @@
+function updateTime() {
+    const now = new Date();
+    const options = { hour: '2-digit', minute: '2-digit', second: '2-digit' };
+    document.getElementById('tokyo').textContent = new Intl.DateTimeFormat('en-US', { ...options, timeZone: 'Asia/Tokyo' }).format(now);
+    document.getElementById('paris').textContent = new Intl.DateTimeFormat('en-US', { ...options, timeZone: 'Europe/Paris' }).format(now);
+    document.getElementById('bogota').textContent = new Intl.DateTimeFormat('en-US', { ...options, timeZone: 'America/Bogota' }).format(now);
+}
+
+setInterval(updateTime, 1000);
+updateTime();

--- a/time.html
+++ b/time.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>World Time</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous" />
+</head>
+<body>
+    <div class="container text-center mt-5">
+        <h1>World Clock</h1>
+        <p><strong>Tokyo:</strong> <span id="tokyo"></span></p>
+        <p><strong>Paris:</strong> <span id="paris"></span></p>
+        <p><strong>Bogotá:</strong> <span id="bogota"></span></p>
+    </div>
+    <script src="js/time.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add world clock page displaying current time in Tokyo, Paris, and Bogotá
- implement JavaScript updater for time zones

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3389c9b48330bf98aaaddce72901